### PR TITLE
Add Heading component

### DIFF
--- a/.changeset/two-humans-smash.md
+++ b/.changeset/two-humans-smash.md
@@ -1,0 +1,5 @@
+---
+"@jandrade/ds-typography": minor
+---
+
+Adds `Heading` to the Typography package

--- a/package-lock.json
+++ b/package-lock.json
@@ -2518,6 +2518,10 @@
             "resolved": "packages/theme",
             "link": true
         },
+        "node_modules/@jandrade/ds-typography": {
+            "resolved": "packages/typography",
+            "link": true
+        },
         "node_modules/@jest/console": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
@@ -33094,12 +33098,20 @@
         },
         "packages/theme": {
             "name": "@jandrade/ds-theme",
-            "version": "0.0.0",
+            "version": "0.2.0",
             "license": "ISC",
             "devDependencies": {
                 "@vanilla-extract/css": "^1.6.8",
                 "@vanilla-extract/css-utils": "^0.1.2",
                 "chroma-js": "^2.4.2"
+            }
+        },
+        "packages/typography": {
+            "name": "@jandrade/ds-typography",
+            "version": "0.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "@jandrade/ds-theme": "^0.2.0"
             }
         }
     },
@@ -34919,6 +34931,12 @@
                 "@vanilla-extract/css": "^1.6.8",
                 "@vanilla-extract/css-utils": "^0.1.2",
                 "chroma-js": "^2.4.2"
+            }
+        },
+        "@jandrade/ds-typography": {
+            "version": "file:packages/typography",
+            "requires": {
+                "@jandrade/ds-theme": "*"
             }
         },
         "@jest/console": {

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -1,0 +1,3 @@
+# @jandrade/ds-typography
+
+This package contains Typography components like `Heading`, `Text`, `Body`, etc.

--- a/packages/typography/index.ts
+++ b/packages/typography/index.ts
@@ -1,0 +1,3 @@
+import { Heading } from "./src/heading";
+
+export default Heading;

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@jandrade/ds-typography",
+    "version": "0.0.0",
+    "description": "",
+    "main": "src/index.ts",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jandrade/ds-components.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "homepage": "https://github.com/jandrade/ds-components#readme",
+    "dependencies": {
+        "@jandrade/ds-theme": "^1.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -14,7 +14,7 @@
     "license": "ISC",
     "homepage": "https://github.com/jandrade/ds-components#readme",
     "dependencies": {
-        "@jandrade/ds-theme": "^1.0.0"
+        "@jandrade/ds-theme": "^0.2.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/typography/src/heading.css.ts
+++ b/packages/typography/src/heading.css.ts
@@ -1,0 +1,42 @@
+import { recipe } from "@vanilla-extract/recipes";
+
+import { vars } from "@jandrade/ds-theme";
+
+export const heading = recipe({
+    base: {
+        fontFamily: vars.typography.font.body,
+        fontWeight: vars.typography.fontWeight.regular,
+        lineHeight: vars.typography.lineHeight.md,
+        color: vars.color.text.body,
+    },
+
+    variants: {
+        level: {
+            1: {
+                marginTop: 0,
+                fontSize: vars.typography.fontSize.xxl,
+                lineHeight: vars.typography.lineHeight.xxl,
+            },
+            2: {
+                fontSize: vars.typography.fontSize.xl,
+                lineHeight: vars.typography.lineHeight.xl,
+            },
+            3: {
+                fontSize: vars.typography.fontSize.lg,
+                lineHeight: vars.typography.lineHeight.lg,
+            },
+            4: {
+                fontSize: vars.typography.fontSize.md,
+                lineHeight: vars.typography.lineHeight.md,
+            },
+            5: {
+                fontSize: vars.typography.fontSize.sm,
+                lineHeight: vars.typography.lineHeight.sm,
+            },
+            6: {
+                fontSize: vars.typography.fontSize.xs,
+                lineHeight: vars.typography.lineHeight.xs,
+            },
+        },
+    },
+});

--- a/packages/typography/src/heading.stories.tsx
+++ b/packages/typography/src/heading.stories.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
+
+import { Heading, HeadingLevel } from "./heading";
+
+import { vars } from "@jandrade/ds-theme";
+
+export default {
+    title: "Components / Typography / Heading",
+    component: Heading,
+    args: {
+        level: 2,
+    },
+} as ComponentMeta<typeof Heading>;
+
+type Story = ComponentStoryObj<typeof Heading>;
+
+export const Default: Story = { args: { children: "This is the main title" } };
+
+export const AllLevels = () =>
+    new Array(6).fill(null).map((_, i) => {
+        const level = (i + 1) as HeadingLevel;
+        // if (level === 2) {
+        //     return null;
+        // }
+        return (
+            <div
+                key={i}
+                style={{ background: vars.color.background.secondaryLight }}
+            >
+                <Heading level={level}>Heading {i + 1}</Heading>
+            </div>
+        );
+    });
+
+AllLevels.parameters = {
+    docs: {
+        description: {
+            story: "Headings are used as the titles of each major section of a page. Below you can see all the different heading levels available.",
+        },
+    },
+};

--- a/packages/typography/src/heading.tsx
+++ b/packages/typography/src/heading.tsx
@@ -1,0 +1,32 @@
+import React, { ElementType } from "react";
+
+import { heading } from "./heading.css";
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface HeadingProps {
+    /**
+     * Heading content.
+     */
+    children: React.ReactNode;
+    /**
+     * The heading level. From 1 to 6.
+     */
+    level?: HeadingLevel;
+}
+
+/**
+ * A heading component used to create various levels of typographic hierarchies.
+ *
+ * ## Usage
+ *
+ * ```jsx
+ * import {Heading} from "ds-typography";
+ *
+ * <Heading level={1}>This is the main title</Heading>
+ * ```
+ */
+export function Heading({ children, level = 2 }: HeadingProps) {
+    const HeadingTag = `h${level}` as ElementType;
+    return <HeadingTag className={heading({ level })}>{children}</HeadingTag>;
+}


### PR DESCRIPTION
- Adding a new `ds-typography` package.
- Creating the `Heading` component.
- Added stories to include usage examples.
